### PR TITLE
Initial implementation: Ping API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module api
+
+go 1.19

--- a/handlers/ping.go
+++ b/handlers/ping.go
@@ -1,0 +1,13 @@
+package handlers
+
+import "net/http"
+
+func PingHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Pong!"))
+}

--- a/handlers/ping_test.go
+++ b/handlers/ping_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPingHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		expectedCode   int
+		expectedBody   string
+	}{
+		{
+			name:           "GET request returns Pong",
+			method:         http.MethodGet,
+			expectedCode:   http.StatusOK,
+			expectedBody:   "Pong!",
+		},
+		{
+			name:           "POST request returns method not allowed",
+			method:         http.MethodPost,
+			expectedCode:   http.StatusMethodNotAllowed,
+			expectedBody:   "Method not allowed\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/v1/ping", nil)
+			w := httptest.NewRecorder()
+
+			PingHandler(w, req)
+
+			if w.Code != tt.expectedCode {
+				t.Errorf("expected status code %d, got %d", tt.expectedCode, w.Code)
+			}
+
+			if w.Body.String() != tt.expectedBody {
+				t.Errorf("expected body %q, got %q", tt.expectedBody, w.Body.String())
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"api/handlers"
+)
+
+func main() {
+	http.HandleFunc("/v1/ping", handlers.PingHandler)
+	log.Println("Server starting on :8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds:
- Basic Go HTTP server setup
- GET /v1/ping endpoint implementation
- Unit tests for the ping handler
- .gitignore file